### PR TITLE
Add support for rendering attributes

### DIFF
--- a/Addon/Attributes/PropertyToHtmlAttribute.cs
+++ b/Addon/Attributes/PropertyToHtmlAttribute.cs
@@ -2,11 +2,11 @@
 
 namespace RenderingLayoutProcessor.Attributes
 {
-    public class RenderAttribute : Attribute
+    public class PropertyToHtmlAttributeAttribute : Attribute
     {
         private string attributeName;
         private bool renderIfEmpty = false;
-        public RenderAttribute(string attributeName = null, bool renderIfEmpty = false)
+        public PropertyToHtmlAttributeAttribute(string attributeName = null, bool renderIfEmpty = false)
         {
             this.attributeName = attributeName;
             this.renderIfEmpty = renderIfEmpty;

--- a/Addon/Attributes/RenderAttribute.cs
+++ b/Addon/Attributes/RenderAttribute.cs
@@ -1,0 +1,25 @@
+﻿using System;
+
+namespace RenderingLayoutProcessor.Attributes
+{
+    public class RenderAttribute : Attribute
+    {
+        private string attributeName;
+        private bool renderIfEmpty = false;
+        public RenderAttribute(string attributeName = null, bool renderIfEmpty = false)
+        {
+            this.attributeName = attributeName;
+            this.renderIfEmpty = renderIfEmpty;
+        }
+
+        public virtual string AttributeName
+        {
+            get { return attributeName; }
+        }
+
+        public virtual bool RenderIfEmpty
+        {
+            get { return renderIfEmpty; }
+        }
+    }
+}

--- a/Addon/Context/AttributeRenderingContext.cs
+++ b/Addon/Context/AttributeRenderingContext.cs
@@ -31,8 +31,25 @@ namespace RenderingLayoutProcessor.Context
                 rowTag.AddCssClass(rowClass);
             }
             var blockMetadata = htmlHelper.BlockMetadata();
+            if (blockMetadata is null)
+            {
+                rowTag.RenderOpenTo(htmlHelper);
+                return;
+            }
+
             rowTag.MergeAttribute("data-layout", blockMetadata.ParentMetadata.ContentLink.ID.ToString());
             rowTag.MergeAttribute("data-layout-index", blockMetadata.ParentMetadata.Index.ToString());
+
+            var block = blockMetadata.GetContent<ContentData>();
+            if (block != null)
+            {
+                var attributes = block.GetRenderAttributes();
+                foreach(var attribute in attributes)
+                {
+                    rowTag.MergeAttribute(attribute.Key, attribute.Value);
+                }
+            }
+
             rowTag.RenderOpenTo(htmlHelper);
         }
 

--- a/Addon/Extension/ContentAreaContextExtensions.cs
+++ b/Addon/Extension/ContentAreaContextExtensions.cs
@@ -37,7 +37,7 @@ namespace RenderingLayoutProcessor.Extension
         {
             var attributes = new Dictionary<string, string>();
             
-            var renderAttributeProperties = instance.GetType().GetProperties().Where(prop => Attribute.IsDefined(prop, typeof(RenderAttribute)));
+            var renderAttributeProperties = instance.GetType().GetProperties().Where(prop => Attribute.IsDefined(prop, typeof(PropertyToHtmlAttributeAttribute)));
             var contentType = instance.GetType();
             foreach (var attributeProp in renderAttributeProperties)
             {
@@ -50,7 +50,7 @@ namespace RenderingLayoutProcessor.Extension
                     propertyValue = propertyValue.ToLowerInvariant();
                 }
 
-                var renderAttribute = contentType.GetProperty(attributeProp.Name).GetCustomAttribute<RenderAttribute>();
+                var renderAttribute = contentType.GetProperty(attributeProp.Name).GetCustomAttribute<PropertyToHtmlAttributeAttribute>();
                 if (string.IsNullOrEmpty(propertyValue) && !renderAttribute.RenderIfEmpty)
                 {
                     continue;

--- a/Addon/RenderingLayoutProcessor.csproj
+++ b/Addon/RenderingLayoutProcessor.csproj
@@ -11,7 +11,7 @@
 	<RepositoryUrl>https://github.com/JoshuaFolkerts/RenderingLayoutProcessor</RepositoryUrl>
 	<Copyright />
 	<Authors>Joshua Folkerts, Erik Kärrsgård, Blend Interactive, Wezz Balk</Authors>
-	<Version>5.0.5</Version>
+	<Version>5.0.6</Version>
 	<Description>RenderingLayoutProcessor is an extension to Episerver/Optimizely that makes it possible to add layout blocks that will control how the next x blocks will display.</Description>
 	<Product>RenderingLayoutProcessor</Product>
   </PropertyGroup>

--- a/Site/Models/MultiCol/NoFrameworkLayoutBlock.cs
+++ b/Site/Models/MultiCol/NoFrameworkLayoutBlock.cs
@@ -2,6 +2,8 @@
 using RenderingLayoutProcessor;
 using RenderingLayoutProcessor.Block;
 using RenderingLayoutProcessor.Context;
+using RenderingLayoutProcessor.Attributes;
+using System.ComponentModel.DataAnnotations;
 
 namespace Site.Models.MultiCol
 {
@@ -10,5 +12,21 @@ namespace Site.Models.MultiCol
     {
         public override IRenderingContentAreaContext NewContext() =>
             new AttributeRenderingContext();
+
+        [Display(
+            Name = "Background",
+            Description = "",
+            Order = 100)]
+        [CultureSpecific]
+        [RenderAttribute]
+        public virtual string Background { get; set; }
+
+        [Display(
+            Name = "Hidden",
+            Description = "",
+            Order = 200)]
+        [CultureSpecific]
+        [RenderAttribute("aria-hidden", true)]
+        public virtual bool Hidden { get; set; }
     }
 }

--- a/Site/Models/MultiCol/NoFrameworkLayoutBlock.cs
+++ b/Site/Models/MultiCol/NoFrameworkLayoutBlock.cs
@@ -18,7 +18,7 @@ namespace Site.Models.MultiCol
             Description = "",
             Order = 100)]
         [CultureSpecific]
-        [RenderAttribute]
+        [PropertyToHtmlAttribute]
         public virtual string Background { get; set; }
 
         [Display(
@@ -26,7 +26,7 @@ namespace Site.Models.MultiCol
             Description = "",
             Order = 200)]
         [CultureSpecific]
-        [RenderAttribute("aria-hidden", true)]
+        [PropertyToHtmlAttribute("aria-hidden", true)]
         public virtual bool Hidden { get; set; }
     }
 }


### PR DESCRIPTION
I've added support for Rendering Attributes where you can specify attributes on properties to be rendered on the layout blocks wrapping tags. 

The attributes can of course be reused and implemented on content blocks themselves 