### PR TITLE
Fixes issue with non matching constructor arguments of ContentAreaRenderer

### DIFF
--- a/Addon/AddOn.Optimizely.ContentAreaLayout.csproj
+++ b/Addon/AddOn.Optimizely.ContentAreaLayout.csproj
@@ -11,13 +11,13 @@
 	<RepositoryUrl>https://github.com/JoshuaFolkerts/AddOn.Optimizely.ContentAreaLayout</RepositoryUrl>
 	<Copyright />
 	<Authors>Joshua Folkerts, Erik Kärrsgård, Blend Interactive, Wezz Balk</Authors>
-	<Version>3.0.0</Version>
+	<Version>4.0.0</Version>
 	<Description>AddOn.Optimizely.ContentAreaLayout is an extension to Episerver/Optimizely that makes it possible to add layout blocks that will control how the next x blocks will display.</Description>
 	<Product>AddOn.Optimizely.ContentAreaLayout</Product>
   </PropertyGroup>
 
   <ItemGroup>
-	<PackageReference Include="EPiServer.CMS.AspNetCore.HtmlHelpers" Version="12.11.0" />
+	<PackageReference Include="EPiServer.CMS.AspNetCore.HtmlHelpers" Version="12.13.0" />
 	<PackageReference Include="EPiServer.CMS.UI.Core" Version="12.15.0" />
 	<FrameworkReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>

--- a/Addon/Extension/ContentAreaContextExtensions.cs
+++ b/Addon/Extension/ContentAreaContextExtensions.cs
@@ -35,11 +35,17 @@ namespace AddOn.Optimizely.ContentAreaLayout.Extension
         
         public static Dictionary<string, string> GetBlockMetadataProperties(this IContent instance)
         {
+            return GetBlockMetadataProperties(instance as IContentData);
+        }
+        
+        public static Dictionary<string, string> GetBlockMetadataProperties(this IContentData instance)
+        {
             var properties = new Dictionary<string, string>();
             if (instance is null || !(instance is ContentData content))
             {
                 return properties;
             }
+
             var sourceProperties = content.GetPropertyAttributes<BlockRenderingMetadataAttributeAttribute>();
             if (!sourceProperties?.Any() ?? false)
             {

--- a/Site/Site.csproj
+++ b/Site/Site.csproj
@@ -5,7 +5,10 @@
   </PropertyGroup>
   
   <ItemGroup>
-    <PackageReference Include="EPiServer.CMS" Version="12.15.1" />
+    <PackageReference Include="EPiServer.CMS" Version="12.16.1" />
+    <PackageReference Include="EPiServer.CMS.AspNetCore.HtmlHelpers" Version="12.13.0" />
+    <PackageReference Include="EPiServer.Framework" Version="12.13.0" />
+    <PackageReference Include="EPiServer.Hosting" Version="12.13.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="6.0.4" />
     <PackageReference Include="Wangkanai.Detection" Version="2.0.1" />
   </ItemGroup>

--- a/Tests/TestBase.cs
+++ b/Tests/TestBase.cs
@@ -8,8 +8,6 @@ using EPiServer.Core;
 using EPiServer.DataAbstraction;
 using EPiServer.Framework.Web;
 using EPiServer.Web;
-using EPiServer.Web.Internal;
-using EPiServer.Web.Mvc;
 using EPiServer.Web.Templating;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc.ModelBinding;
@@ -20,7 +18,6 @@ using Moq;
 using AddOn.Optimizely.ContentAreaLayout;
 using AddOn.Optimizely.ContentAreaLayout.Context;
 using AddOn.Optimizely.ContentAreaLayout.Extension;
-using System.Threading.Tasks;
 
 namespace Tests
 {
@@ -67,7 +64,6 @@ namespace Tests
             var contextModeResolver = new Mock<IContextModeResolver>();
             var contentAreaRenderingOptions = new Mock<ContentAreaRenderingOptions>();
             var modelMetadataProvider = new Mock<IModelMetadataProvider>();
-            var modelExplorerFactory = new Mock<ModelExplorerFactory>(modelMetadataProvider.Object);
             var modelTemplateTagResolver = new Mock<IModelTemplateTagResolver>();
 
             var htmlHelper = new Mock<IHtmlHelper>();
@@ -94,7 +90,7 @@ namespace Tests
             foreach (var content in contentItems ?? new List<IContent> { new BasicContent { ContentLink = new ContentReference(100) } })
             {
                 var contentAreaItem = new Mock<ContentAreaItem>();
-                contentAreaLoader.Setup(x => x.Get(contentAreaItem.Object))
+                contentAreaLoader.Setup(x => x.LoadContent(contentAreaItem.Object))
                     .Returns(content);
                 contentAreaItems.Add(contentAreaItem);
             }
@@ -127,7 +123,7 @@ namespace Tests
                 contentAreaLoader.Object,
                 contextModeResolver.Object,
                 contentAreaRenderingOptions.Object,
-                modelExplorerFactory.Object,
+                modelMetadataProvider.Object,
                 modelTemplateTagResolver.Object)
             {
                 RenderContent = ContentRenderer


### PR DESCRIPTION
As of v12.13.x the constructor no longer takes a ModelExplorer which causes runtime exceptions during startup.

Also fixes an obsoleted call to ContentAreLoader.Get -> LoadContent

Bumps version to 4.0 as this is a breaking change.

Fixes: #20