### PR TITLE
Support higher versions of Episerver.CMS

### DIFF
--- a/Addon/AddOn.Optimizely.ContentAreaLayout.csproj
+++ b/Addon/AddOn.Optimizely.ContentAreaLayout.csproj
@@ -17,7 +17,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-	<PackageReference Include="EPiServer.CMS.AspNetCore.HtmlHelpers" Version="12.13.0" />
+	<PackageReference Include="EPiServer.CMS.AspNetCore.HtmlHelpers" Version="[12.13, 13)" />
 	<PackageReference Include="EPiServer.CMS.UI.Core" Version="[12.15,13)" />
 	<FrameworkReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>

--- a/Addon/AddOn.Optimizely.ContentAreaLayout.csproj
+++ b/Addon/AddOn.Optimizely.ContentAreaLayout.csproj
@@ -18,7 +18,7 @@
 
   <ItemGroup>
 	<PackageReference Include="EPiServer.CMS.AspNetCore.HtmlHelpers" Version="12.11.0" />
-	<PackageReference Include="EPiServer.CMS.UI.Core" Version="[12.5,13)" />
+	<PackageReference Include="EPiServer.CMS.UI.Core" Version="[12.15,13)" />
 	<FrameworkReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
 </Project>

--- a/Addon/AddOn.Optimizely.ContentAreaLayout.csproj
+++ b/Addon/AddOn.Optimizely.ContentAreaLayout.csproj
@@ -18,7 +18,7 @@
 
   <ItemGroup>
 	<PackageReference Include="EPiServer.CMS.AspNetCore.HtmlHelpers" Version="12.11.0" />
-	<PackageReference Include="EPiServer.CMS.UI.Core" Version="12.15.0" />
+	<PackageReference Include="EPiServer.CMS.UI.Core" Version="[12.5,13)" />
 	<FrameworkReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
 </Project>

--- a/Addon/Extension/ContentAreaContextExtensions.cs
+++ b/Addon/Extension/ContentAreaContextExtensions.cs
@@ -33,7 +33,7 @@ namespace AddOn.Optimizely.ContentAreaLayout.Extension
             return blockMetadata;
         }
         
-        public static Dictionary<string, string> GetBlockMetadataProperties(this IContent instance)
+        public static Dictionary<string, string> GetBlockMetadataProperties(this IContentData instance)
         {
             var properties = new Dictionary<string, string>();
             if (instance is null || !(instance is ContentData content))
@@ -63,19 +63,20 @@ namespace AddOn.Optimizely.ContentAreaLayout.Extension
             return properties;
         }
 
-        public static Dictionary<string, string> GetPropertyAttributes<T>(this ContentData instance) where T : System.Attribute
+        public static Dictionary<string, string> GetPropertyAttributes<T>(this IContentData instance) where T : System.Attribute
         {
             var attributes = new Dictionary<string, string>();
-            if (instance is null)
+            if (instance is null || !(instance is ContentData content))
             {
                 return attributes;
             }
 
-            var renderAttributeProperties = instance.GetType().GetProperties().Where((prop) => System.Attribute.IsDefined(prop, typeof(T)));
+
+            var renderAttributeProperties = content.GetType().GetProperties().Where((prop) => System.Attribute.IsDefined(prop, typeof(T)));
 
             foreach (var attributeProp in renderAttributeProperties)
             {
-                var propertyValue = instance.GetPropertyValue(attributeProp.Name, string.Empty);
+                var propertyValue = content.GetPropertyValue(attributeProp.Name, string.Empty);
 
                 if (attributeProp.PropertyType == typeof(bool))
                 {
@@ -87,7 +88,7 @@ namespace AddOn.Optimizely.ContentAreaLayout.Extension
             return attributes;
         }
 
-        public static Dictionary<string, string> GetRenderAttributes(this ContentData instance)
+        public static Dictionary<string, string> GetRenderAttributes(this IContentData instance)
         {
             var attributes = new Dictionary<string, string>();
             if (instance is null)


### PR DESCRIPTION
Now we're locked to a specific Episerver.CMS version 12.15. 
This becomes an issue when updating package dependent on ContentAreaLayout service that is above that version 