### PR TITLE
Feature/#25 support inline block

### DIFF
--- a/Addon/ContentAreaLayoutRenderer.cs
+++ b/Addon/ContentAreaLayoutRenderer.cs
@@ -270,7 +270,7 @@ namespace AddOn.Optimizely.ContentAreaLayout
                 }
                 
                 // Render the content
-                RenderContent(htmlHelper, content as IContent, templateModel);
+                RenderContent(htmlHelper, content, templateModel);
    
                 tagBuilder?.RenderCloseTo(htmlHelper);
             }


### PR DESCRIPTION
Hi! I removed some castings IContent to support the inline block type since this block type is not IContent.