### PR TITLE
Add support for Container classes with and without layout blocks

### DIFF
--- a/Addon/Context/AttributeRenderingContext.cs
+++ b/Addon/Context/AttributeRenderingContext.cs
@@ -34,6 +34,10 @@ namespace AddOn.Optimizely.ContentAreaLayout.Context
             rowTag.MergeAttribute("data-layout", blockMetadata.ParentMetadata.ContentLink.ID.ToString());
             rowTag.MergeAttribute("data-layout-index", blockMetadata.ParentMetadata.Index.ToString());
             rowTag.MergeAttribute("data-layout-children", blockMetadata.ParentMetadata.Children.ToString());
+            if (htmlHelper.ViewContext.ViewData.ContainsKey("ContainerCssClass"))
+            {
+                rowTag.Attributes.Add("class", htmlHelper.ViewContext.ViewData["ContainerCssClass"].ToString());
+            }
             foreach (var property in blockMetadata.ParentMetadata.Properties)
             {
                 rowTag.MergeAttribute(property.Key, property.Value);

--- a/Addon/Context/AttributeRenderingFallbackContext.cs
+++ b/Addon/Context/AttributeRenderingFallbackContext.cs
@@ -18,6 +18,10 @@ namespace AddOn.Optimizely.ContentAreaLayout.Context
             contentAreaContainer = new TagBuilder("div");
             contentAreaContainer.Attributes.Add("data-contentarea", String.Empty);
             contentAreaContainer.Attributes.Add("data-contentarea-children", blockMetadata.ParentMetadata.Children.ToString());
+            if (htmlHelper.ViewContext.ViewData.ContainsKey("ContainerCssClass"))
+            {
+                contentAreaContainer.Attributes.Add("class", htmlHelper.ViewContext.ViewData["ContainerCssClass"].ToString());
+            }
             
             // If a viewbag value that contains any property that is not excluded we add it as a data attribute
             var contentAreaViewDataAttributes = htmlHelper.ViewContext.ViewData


### PR DESCRIPTION
It's currently not possible to add classes to the element that will be wrapping the blocks themselves. 
Adding CssClass to a PropertyFor will just add an additional wrapping element. 

This PR will add the possibility to add a ContainerCssClass option to the property for that will get picked up in both the AttributeRenderingContext and AttributeRenderingContentAreaFallbackContext