### PR TITLE
Set block metadata attributes in default context

### DIFF
--- a/Addon/Context/DefaultContentAreaContext.cs
+++ b/Addon/Context/DefaultContentAreaContext.cs
@@ -30,6 +30,7 @@ namespace AddOn.Optimizely.ContentAreaLayout.Context
         
         public virtual void ItemOpen(IHtmlHelper htmlHelper, BlockRenderingMetadata blockMetadata)
         {
+            htmlHelper.ViewContext.ViewData[RenderingMetadataKeys.Block] = blockMetadata;
         }
 
         public virtual void ItemClose(IHtmlHelper htmlHelper)


### PR DESCRIPTION
Metadata attributes are useful even when theres is no parent layout block. E.g. unique id is needed for javascript that targets multiple blocks of the same type on one page.